### PR TITLE
automation: Use copr instead of resurces.ovirt.org

### DIFF
--- a/automation/containers/ovirt-provider-ovn-tests/Dockerfile.centos-8
+++ b/automation/containers/ovirt-provider-ovn-tests/Dockerfile.centos-8
@@ -1,7 +1,7 @@
 FROM centos/centos:stream8
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_tests"
 
-# Workround for https://bugzilla.redhat.com/2024629
+# Workaround for https://bugzilla.redhat.com/2024629
 RUN rpm --import \
         https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg \
     && \

--- a/automation/containers/ovirt-provider-ovn/Dockerfile.centos-8
+++ b/automation/containers/ovirt-provider-ovn/Dockerfile.centos-8
@@ -1,8 +1,12 @@
 FROM centos/centos:stream8
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_integ_tests"
 
-RUN dnf install -y \
-        https://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
+# Workaround for https://bugzilla.redhat.com/2024629
+RUN rpm --import \
+        https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg \
+    && \
+    dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ \
+        install -y ovirt-release-master \
     && \
     dnf update -y \
     && \

--- a/automation/containers/ovirt-provider-ovn/Dockerfile.centos-9
+++ b/automation/containers/ovirt-provider-ovn/Dockerfile.centos-9
@@ -1,8 +1,12 @@
 FROM centos/centos:stream9-development
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_integ_tests"
 
-RUN dnf install -y \
-        https://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
+# The copr plugin is installed by default on el8stream
+RUN dnf -y install yum-plugin-copr \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    && \
+    dnf install -y ovirt-release-master \
     && \
     dnf update -y \
     && \

--- a/automation/containers/ovn-controller/Dockerfile.centos-8
+++ b/automation/containers/ovn-controller/Dockerfile.centos-8
@@ -1,8 +1,12 @@
 FROM centos/centos:stream8
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_integ_tests"
 
-RUN dnf install -y \
-        https://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
+# Workaround for https://bugzilla.redhat.com/2024629
+RUN rpm --import \
+        https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg \
+    && \
+    dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ \
+        install -y ovirt-release-master \
     && \
     dnf update -y \
     && \

--- a/automation/containers/ovn-controller/Dockerfile.centos-9
+++ b/automation/containers/ovn-controller/Dockerfile.centos-9
@@ -1,8 +1,12 @@
 FROM centos/centos:stream9-development
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_integ_tests"
 
-RUN dnf install -y \
-        https://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm \
+# The copr plugin is installed by default on el8stream
+RUN dnf -y install yum-plugin-copr \
+    && \
+    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    && \
+    dnf install -y ovirt-release-master \
     && \
     dnf update -y \
     && \


### PR DESCRIPTION
Use the reporsitory from copr instead of resources.ovirt.org
which is getting outdated quickly.
