### PR TITLE
automation: Update el9stream container tag

### DIFF
--- a/automation/containers/ovirt-provider-ovn-tests/Dockerfile.centos-9
+++ b/automation/containers/ovirt-provider-ovn-tests/Dockerfile.centos-9
@@ -1,4 +1,4 @@
-FROM centos/centos:stream9-development
+FROM centos/centos:stream9
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_tests"
 
 # The copr plugin is installed by default on el8stream

--- a/automation/containers/ovirt-provider-ovn/Dockerfile.centos-9
+++ b/automation/containers/ovirt-provider-ovn/Dockerfile.centos-9
@@ -1,4 +1,4 @@
-FROM centos/centos:stream9-development
+FROM centos/centos:stream9
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_integ_tests"
 
 # The copr plugin is installed by default on el8stream

--- a/automation/containers/ovn-controller/Dockerfile.centos-9
+++ b/automation/containers/ovn-controller/Dockerfile.centos-9
@@ -1,4 +1,4 @@
-FROM centos/centos:stream9-development
+FROM centos/centos:stream9
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_integ_tests"
 
 # The copr plugin is installed by default on el8stream


### PR DESCRIPTION
The el9stream has released, now the centos container
image provides tag el9stream, use that instead of
el9stream-development.

