### PR TITLE
ipv6: support ::/0 default route

### DIFF
--- a/provider/constants.py
+++ b/provider/constants.py
@@ -72,7 +72,8 @@ TABLE_ROUTES = 'Logical_Router_Static_Route'
 ROW_ROUTES_IP_PREFIX = 'ip_prefix'
 ROW_ROUTES_NEXTHOP = 'nexthop'
 
-DEFAULT_ROUTE = '0.0.0.0/0'
+DEFAULT_ROUTE4 = '0.0.0.0/0'
+DEFAULT_ROUTE6 = '::/0'
 
 TABLE_PORT_GROUP = 'Port_Group'
 ROW_PG_NAME = 'name'

--- a/provider/neutron/ip.py
+++ b/provider/neutron/ip.py
@@ -190,3 +190,11 @@ def get_subnet_gateway(subnet):
         if is_subnet_ipv4(subnet)
         else subnet.external_ids.get('router')
     )
+
+
+def get_default_route(subnet):
+    return (
+        ovnconst.DEFAULT_ROUTE4
+        if is_subnet_ipv4(subnet)
+        else ovnconst.DEFAULT_ROUTE6
+    )

--- a/provider/neutron/neutron_api.py
+++ b/provider/neutron/neutron_api.py
@@ -1001,7 +1001,7 @@ class NeutronApi(object):
             subnet = self.ovn_north.get_dhcp(dhcp_id=gateway_subnet_id)
             self.ovn_north.add_route(
                 lrp_id=router_id,
-                prefix=ovnconst.DEFAULT_ROUTE,
+                prefix=ip_utils.get_default_route(subnet),
                 nexthop=ip_utils.get_subnet_gateway(subnet),
             )
 
@@ -1463,7 +1463,8 @@ class NeutronApi(object):
             ovnconst.ROW_LR_EXTERNAL_IDS,
             RouterMapper.OVN_ROUTER_GATEWAY_PORT,
         )
-        self.ovn_north.remove_static_route(lr, ovnconst.DEFAULT_ROUTE)
+        self.ovn_north.remove_static_route(lr, ovnconst.DEFAULT_ROUTE4)
+        self.ovn_north.remove_static_route(lr, ovnconst.DEFAULT_ROUTE6)
         self._release_network_ip(ls_id, lrp_ip)
 
     def _is_subnet_on_router(self, router_id, subnet_id):

--- a/provider/neutron/validation.py
+++ b/provider/neutron/validation.py
@@ -249,11 +249,12 @@ def subnet_is_ovirt_managed(subnet):
 
 
 def no_default_gateway_in_routes(default_gateway_exists, routes):
+    destination = RouterMapper.REST_ROUTER_DESTINATION
     if default_gateway_exists and routes:
         if list(
             filter(
-                lambda r: r[RouterMapper.REST_ROUTER_DESTINATION]
-                == ovnconst.DEFAULT_ROUTE,
+                lambda r: r[destination] == ovnconst.DEFAULT_ROUTE4
+                or r[destination] == ovnconst.DEFAULT_ROUTE6,
                 routes,
             )
         ):


### PR DESCRIPTION
Support an ip_prefix of ::/0 for IPv6 routes.

Signed-off-by: Eitan Raviv <eraviv@redhat.com>
Change-Id: Ieaabfab062d5aa69823ee642fe4d6cbe5b8acbdb