### PR TITLE
neturon: Add support for extension API

### DIFF
--- a/provider/constants.py
+++ b/provider/constants.py
@@ -82,3 +82,7 @@ ROW_PG_EXTERNAL_IDS = 'external_ids'
 TABLE_ACL = 'ACL'
 
 TABLE_ADDRESS_SET = 'Address_Set'
+
+# Extensions
+EXTENSION_UPDATED = '2022-02-28T00:00:00-00:00'
+SUPPORTED_EXTENSIONS = [('Neutron Extra Route', 'extraroute')]

--- a/provider/handlers/neutron_responses.py
+++ b/provider/handlers/neutron_responses.py
@@ -36,6 +36,7 @@ SUBNET_ID = 'subnet_id'
 ROUTER_ID = 'router_id'
 SECURITY_GROUP_ID = 'security_group_id'
 SECURITY_GROUP_RULE_ID = 'security_group_rule_id'
+ALIAS = 'alias'
 
 NETWORKS = 'networks'
 NETWORK_ENTITY = 'networks/{network_id}'
@@ -51,6 +52,8 @@ ADD_ROUTER_INTERFACE = 'routers/{router_id}/add_router_interface'
 DELETE_ROUTER_INTERFACE = 'routers/{router_id}/remove_router_interface'
 SECURITY_GROUP_RULES = 'security-group-rules'
 SECURITY_GROUP_RULE_ENTITY = 'security-group-rules/{security_group_rule_id}'
+EXTENSIONS = 'extensions'
+EXTENSION_ENTITY = 'extensions/{alias}'
 
 FLOATINGIPS = 'floatingips'
 
@@ -88,6 +91,17 @@ def get_default(nb_db, content, parameters):
             ]
         }
     )
+
+
+@rest(GET, EXTENSIONS, _responses)
+def get_extensions(nb_db, content, parameters):
+    return Response({'extensions': nb_db.list_extensions()})
+
+
+@rest(GET, EXTENSION_ENTITY, _responses)
+def show_extension(nb_db, content, parameters):
+    nb_db.get_extension(parameters[ALIAS])
+    return Response()
 
 
 @rest(GET, NETWORKS, _responses)

--- a/provider/neutron/neutron_api.py
+++ b/provider/neutron/neutron_api.py
@@ -1729,3 +1729,27 @@ class NeutronApi(object):
 
     def are_security_groups_supported(self):
         return ovnconst.TABLE_PORT_GROUP in self.idl.tables
+
+    @staticmethod
+    def list_extensions():
+        extensions = []
+        for name, alias in ovnconst.SUPPORTED_EXTENSIONS:
+            extensions.append(
+                {
+                    'updated': ovnconst.EXTENSION_UPDATED,
+                    'name': name,
+                    'alias': alias,
+                    'description': name,
+                    'links': [],
+                }
+            )
+        return extensions
+
+    @staticmethod
+    def get_extension(ext_alias):
+        for _, alias in ovnconst.SUPPORTED_EXTENSIONS:
+            if ext_alias == alias:
+                return
+        raise ElementNotFoundError(
+            f'Cannot find extension with alias "{ext_alias}"'
+        )


### PR DESCRIPTION
When we are changing routes on router through
openstacksdk it expects the correct extension to
be reported. Add extension API with fixed list of
supported extensions, currently "extraroute".