### PR TITLE
Crypto policy workaround

### DIFF
--- a/automation/containers/Makefile
+++ b/automation/containers/Makefile
@@ -29,13 +29,13 @@ all: $(targets)
 $(targets):
 	for name in $(types); do \
 		cd $$name; \
-		$(CONTAINER_CMD) build --no-cache --rm -t $(prefix)/$$name:$@ -f Dockerfile.$@ .; \
+		$(CONTAINER_CMD) build --no-cache --rm -t $(prefix)/$$name:$@ -f Dockerfile.$@ . || exit $$?; \
 		cd -; \
 	done
 
 $(types):
 	for target in $(targets); do \
 		cd $@; \
-		$(CONTAINER_CMD) build --no-cache --rm -t $(prefix)/$@:$$target -f Dockerfile.$$target .; \
+		$(CONTAINER_CMD) build --no-cache --rm -t $(prefix)/$@:$$target -f Dockerfile.$$target . || exit $$?; \
 		cd -; \
 	done

--- a/automation/containers/ovirt-provider-ovn-tests/Dockerfile.centos-9
+++ b/automation/containers/ovirt-provider-ovn-tests/Dockerfile.centos-9
@@ -1,6 +1,12 @@
 FROM centos/centos:stream9
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_tests"
 
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN dnf install -y crypto-policies-scripts crypto-policies \
+    && \
+    update-crypto-policies --set LEGACY
+
 # The copr plugin is installed by default on el8stream
 RUN dnf -y install yum-plugin-copr \
     && \

--- a/automation/containers/ovirt-provider-ovn/Dockerfile.centos-9
+++ b/automation/containers/ovirt-provider-ovn/Dockerfile.centos-9
@@ -1,6 +1,12 @@
 FROM centos/centos:stream9
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_integ_tests"
 
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN dnf install -y crypto-policies-scripts crypto-policies \
+    && \
+    update-crypto-policies --set LEGACY
+
 # The copr plugin is installed by default on el8stream
 RUN dnf -y install yum-plugin-copr \
     && \

--- a/automation/containers/ovn-controller/Dockerfile.centos-9
+++ b/automation/containers/ovn-controller/Dockerfile.centos-9
@@ -1,6 +1,12 @@
 FROM centos/centos:stream9
 LABEL maintainer="amusil@redhat.com" purpose="ovirt_provider_ovn_integ_tests"
 
+# Use legacy cryptopolicy as workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2059101
+# until https://pagure.io/copr/copr/issue/2106 is fixed
+RUN dnf install -y crypto-policies-scripts crypto-policies \
+    && \
+    update-crypto-policies --set LEGACY
+
 # The copr plugin is installed by default on el8stream
 RUN dnf -y install yum-plugin-copr \
     && \


### PR DESCRIPTION
The copr packages were signed by SHA1 which was
removed on el9s, until the relevant BZ [0] is fixed
set crypto policy to lagacy.

[0] https://bugzilla.redhat.com/2059101

Signed-off-by: Ales Musil <amusil@redhat.com>