### PR TITLE
Mark temp repo directory as safe for COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,9 +1,14 @@
-.PHONY: installdeps srpm
+.PHONY: installdeps git_cfg_safe srpm
 
 installdeps:
 	dnf -y install git make python3-devel python3-setuptools systemd
 
-srpm: installdeps
+git_cfg_safe:
+	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
+	# git commands won't work because of the fix for CVE-2022-24765
+	git config --global --add safe.directory "$(shell pwd)"
+
+srpm: installdeps git_cfg_safe
 	mkdir -p tmp.repos/SOURCES
 	make dist
 	rpmbuild \


### PR DESCRIPTION
When building from COPR the project is cloned into temporary directory,
which is not owned by current user. From git 2.35.2 such directory needs
to be marked as safe inn order git commands work correctly.

Signed-off-by: Martin Perina <mperina@redhat.com>
