### PR TITLE
Bump black formatter dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands = pytest --cov=provider \
 sitepackages = false
 skip_install = true
 deps =
-    black==21.6b0
+    black==22.3.0
 commands =
     black \
         -l 79 \


### PR DESCRIPTION
Bump black formatter to newer version
as the old one was not compatible with
newer version of click[0].

[0] https://github.com/psf/black/issues/2964

Signed-off-by: Ales Musil <amusil@redhat.com>