### PR TITLE
containers: Specify COPR chroot explicitly

### DIFF
--- a/automation/containers/ovirt-provider-ovn-tests/Dockerfile.centos-9
+++ b/automation/containers/ovirt-provider-ovn-tests/Dockerfile.centos-9
@@ -10,7 +10,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # The copr plugin is installed by default on el8stream
 RUN dnf -y install yum-plugin-copr \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && \
     dnf install -y ovirt-release-master \
     && \

--- a/automation/containers/ovirt-provider-ovn/Dockerfile.centos-9
+++ b/automation/containers/ovirt-provider-ovn/Dockerfile.centos-9
@@ -10,7 +10,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # The copr plugin is installed by default on el8stream
 RUN dnf -y install yum-plugin-copr \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && \
     dnf install -y ovirt-release-master \
     && \

--- a/automation/containers/ovn-controller/Dockerfile.centos-9
+++ b/automation/containers/ovn-controller/Dockerfile.centos-9
@@ -10,7 +10,7 @@ RUN dnf install -y crypto-policies-scripts crypto-policies \
 # The copr plugin is installed by default on el8stream
 RUN dnf -y install yum-plugin-copr \
     && \
-    dnf copr enable -y ovirt/ovirt-master-snapshot \
+    dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && \
     dnf install -y ovirt-release-master \
     && \


### PR DESCRIPTION
A recent change to DNF COPR plugin [1] makes 'epel-9' the default chroot
used for CentOS Stream 9. Let's specify the 'centos-stream-9' chroot
name that we use in oVirt's COPR explictly.

[1] https://github.com/rpm-software-management/dnf-plugins-core/pull/459

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
